### PR TITLE
Make llm_app.py not dependent on hardcoded name

### DIFF
--- a/bot/llm_app.py
+++ b/bot/llm_app.py
@@ -18,10 +18,18 @@ from langchain.chains.question_answering import load_qa_chain
 from langchain.chains import LLMChain
 from langchain.chat_models import AzureChatOpenAI
 from langchain.prompts.chat import SystemMessagePromptTemplate, HumanMessagePromptTemplate
+import glob
 import pdb
 
-# Get the absolute path to the .env file in the streamlit_app subdirectory
-env_name = os.path.join(os.path.dirname(__file__), "llm_env.env")
+# Find file name in folder that ends with *.env
+env_files = [file for file in glob.glob("*.env") if file != "example.env"]  
+
+# Get the absolute path to the .env file in the current folder
+try:
+    env_name = os.path.join(os.path.dirname(__file__), env_files[0])
+except:
+    folder = os.path.basename(os.getcwd())
+    raise Exception("No *.env file found in /{}. Please create one. If you've added your keys to example.env, please use a different file name because we want to prevent accidental commits of keys in git".format(folder))
 
 # Load environment variables from the .env file
 config = dotenv_values(env_name)

--- a/bot/llm_app.py
+++ b/bot/llm_app.py
@@ -21,8 +21,9 @@ from langchain.prompts.chat import SystemMessagePromptTemplate, HumanMessageProm
 import glob
 import pdb
 
-# Find file name in folder that ends with *.env
-env_files = [file for file in glob.glob("*.env") if file != "example.env"]  
+# Find file name in same folder as this file that ends with *.env
+current_dir = os.path.dirname(os.path.abspath(__file__))  
+env_files = [file for file in glob.glob(os.path.join(current_dir, '*.env')) if "example.env" not in file]  
 
 # Get the absolute path to the .env file in the current folder
 try:


### PR DESCRIPTION
Searching for .env file in folder, but doing error handling when not found to provide clearer messaging and decoupling of example from chain-reaction

- [ ] PR song: https://www.youtube.com/watch?v=C8BP8K-ZuL0
- [ ] If you want to test, please try to run `python llm_app.py` from the `bot/` folder with no .env 
- [ ] Then test with <NEWNAME>.env 

> Exception: No *.env file found in /bot. Please create one. If you've added your keys to example.env, please use a different file name because we want to prevent accidental commits of keys in git